### PR TITLE
Ensure single friend widget is added

### DIFF
--- a/client/app.py
+++ b/client/app.py
@@ -446,7 +446,7 @@ class GUI(Ui_MainWindow):
 
             groupBox.mousePressEvent = openFriend(i)
             groupBox.setCursor(QCursor(Qt.PointingHandCursor))
-        if j > 0:
+        if j >= 0:
             layout.addWidget(overlay)
         layout.addItem(QSpacerItem(0,600))
 


### PR DESCRIPTION
**RE**: https://github.com/MCMi460/NSO-RPC/issues/17#issuecomment-1152932321

**Issue**- `i` is `0` on first friend, which sets `j` to `0` (`j = i % 4`)
Therefore `layout.addWidget(overlay)` is not called:
```
        if j > 0:
            layout.addWidget(overlay)
```

**Fix**? Simply allowing 0 seems to be fine
```
        if j >= 0:
            layout.addWidget(overlay)
```