### PR TITLE
Ensure single friend widget is added

### DIFF
--- a/client/app.py
+++ b/client/app.py
@@ -447,7 +447,11 @@ class GUI(Ui_MainWindow):
             groupBox.mousePressEvent = openFriend(i)
             groupBox.setCursor(QCursor(Qt.PointingHandCursor))
         if j >= 0:
+            overlay.move(0, 0)
+            overlay.setStyleSheet('background-color: transparent; border-radius: 0px; border: 0px;')
+            overlay.setFixedSize(81 * 4 + (4 * 10), 111)
             layout.addWidget(overlay)
+            layout.addWidget(QSplitter(Qt.Horizontal))
         layout.addItem(QSpacerItem(0,600))
 
         page.setLayout(layout)

--- a/client/app.py
+++ b/client/app.py
@@ -446,7 +446,7 @@ class GUI(Ui_MainWindow):
 
             groupBox.mousePressEvent = openFriend(i)
             groupBox.setCursor(QCursor(Qt.PointingHandCursor))
-        if j > 0:
+        if j >= 0:
             layout.addWidget(overlay)
         layout.addItem(QSpacerItem(0,600))
 


### PR DESCRIPTION
Went overkill and deleted branch after realizing my mistake, which closed the PR (sorry): https://github.com/MCMi460/NSO-RPC/pull/18

Also going w/ a fresh PR to be safe.

----

**RE**: https://github.com/MCMi460/NSO-RPC/issues/17#issuecomment-1152932321

**Issue**- `i` is `0` on first friend, which sets `j` to `0` (`j = i % 4`)
Therefore `layout.addWidget(overlay)` is not called:
```
        if j > 0:
            layout.addWidget(overlay)
```

**Fix**? Simply allowing 0 seems to be fine
```
        if j >= 0:
            layout.addWidget(overlay)
```