### PR TITLE
Add start time to RPC

### DIFF
--- a/client/cli.py
+++ b/client/cli.py
@@ -19,6 +19,9 @@ class Discord():
         if session_token and user_lang:
             self.createCTX(session_token, user_lang, targetID)
 
+        self.currentGame = None
+        self.start = int(time.time())
+
     def createCTX(self, session_token, user_lang, targetID = None):
         try:
             self.api = API(session_token, user_lang, targetID)
@@ -84,12 +87,16 @@ class Discord():
         presence = self.user.presence
         if self.rpc:
             if presence.game.name: # Please file an issue if this happens to fail
+                if self.currentGame != presence.game.name:
+                    self.currentGame = presence.game.name
+                    self.start = int(time.time())
                 state = presence.game.sysDescription
                 if not state:
                     state = 'Played for %s hours or more' % (int(presence.game.totalPlayTime / 60 / 5) * 5)
                     if presence.game.totalPlayTime / 60 < 5:
                         state = 'Played for a little while'
-                self.rpc.update(details = presence.game.name, large_image = presence.game.imageUri, large_text = presence.game.name, state = state)
+                self.rpc.update(details = presence.game.name, large_image = presence.game.imageUri, large_text = presence.game.name, state = state, start = self.start)
+
             else:
                 self.rpc.clear()
         # Set GUI


### PR DESCRIPTION
Considering the start was hidden in favor of total time, it seems like some might not want to display it. Opening PR for review/discussion.

**The following would make this even better (TODO)**:

- [ ] Add related config options for:
  - [ ] Game total time
  - [ ] Game session time

---

**Change in action**: (Mario -> Fire Emblem)
![ezgif-3-00d4f25136](https://user-images.githubusercontent.com/6219998/173239437-1b1af376-b74c-4cf3-a286-87e4d68849b5.gif)


