### PR TITLE
Add API.refreshAccessToken() for use in API.updateLogin()

### DIFF
--- a/client/api/__init__.py
+++ b/client/api/__init__.py
@@ -81,6 +81,12 @@ class API():
     def makeRequest(self, route):
         return requests.post(self.url + route, headers = self.headers)
 
+    def refreshAccessToken(self):
+        self.tokenResponse = Nintendo(self.session_token, self.user_lang).getServiceToken()
+        self.id_token = self.tokenResponse['id_token']
+        self.accessToken = self.tokenResponse['access_token']
+        return self.accessToken
+
     def updateLogin(self):
         path = os.path.expanduser('~/Documents/NSO-RPC/tempToken.txt')
         if os.path.isfile(path):
@@ -90,7 +96,7 @@ class API():
                 log('Login from file')
         if time.time() - self.login['time'] < 7170:
             return
-        login = Login(self.userInfo, self.user_lang, self.accessToken, self.guid)
+        login = Login(self.userInfo, self.user_lang, self.refreshAccessToken(), self.guid)
         login.loginToAccount()
         self.headers['Authorization'] = 'Bearer %s' % login.account['result'].get('webApiServerCredential').get('accessToken') # Add authorization token
         self.login = {


### PR DESCRIPTION
**What**? [Token failing to refresh at two hour mark](https://github.com/MCMi460/NSO-RPC/issues/21)
**Why**? https://github.com/MCMi460/NSO-RPC/issues/21#issuecomment-1159227333
**Fix**? Generate new token before logging in again
**Note**: It sounds like more work should be done [around `access_token` vs. `id_token`, and `request_id`,](https://github.com/MCMi460/NSO-RPC/issues/21#issuecomment-1159227333) per @[samuelthomas2774](https://github.com/samuelthomas2774) on #21 to keep things kosher, but this is working for me...

----

**Edit**: So far so good running built executable. No crashes/still logged-in, clicking through the app menus hours later (#12) works fine, etc.

```
TotalHours        : 24.8919162690278
```