### PR TITLE
set correct windows systray icon color

### DIFF
--- a/client/app.py
+++ b/client/app.py
@@ -515,6 +515,27 @@ class SystemTrayApp(QSystemTrayIcon):
         tray.hide()
         MainWindow.show()
 
+    def windowsDarkMode(): #https://stackoverflow.com/a/65349866
+        try:
+            import winreg
+        except ImportError:
+            return False
+        registry = winreg.ConnectRegistry(None, winreg.HKEY_CURRENT_USER)
+        reg_keypath = r'SOFTWARE\Microsoft\Windows\CurrentVersion\Themes\Personalize'
+        try:
+            reg_key = winreg.OpenKey(registry, reg_keypath)
+        except FileNotFoundError:
+            return False
+
+        for i in range(1024):
+            try:
+                value_name, value, _ = winreg.EnumValue(reg_key, i)
+                if value_name == 'AppsUseLightTheme':
+                    return value == 0
+            except OSError:
+                break
+        return False
+
 if __name__ == '__main__':
     app = QApplication(sys.argv)
     app.setQuitOnLastWindowClosed(False)
@@ -532,6 +553,9 @@ if __name__ == '__main__':
         import subprocess
         if not bool(subprocess.Popen('defaults read -g AppleInterfaceStyle', stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell = True).communicate()[0]):
             iconFile = 'taskbarLight.png'
+    if sys.platform.startswith('win'):
+        if not bool(SystemTrayApp.windowsDarkMode()):
+            iconFile = 'taskBarLight.png'
     tray = SystemTrayApp(QIcon(getPath(iconFile)), MainWindow)
     window.setupUi(MainWindow)
     window.selfService()

--- a/client/app.py
+++ b/client/app.py
@@ -515,7 +515,7 @@ class SystemTrayApp(QSystemTrayIcon):
         tray.hide()
         MainWindow.show()
 
-    def windowsDarkMode(): #https://stackoverflow.com/a/65349866
+    def windowsLightMode(): #https://stackoverflow.com/a/65349866
         try:
             import winreg
         except ImportError:
@@ -554,7 +554,7 @@ if __name__ == '__main__':
         if not bool(subprocess.Popen('defaults read -g AppleInterfaceStyle', stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell = True).communicate()[0]):
             iconFile = 'taskbarLight.png'
     if sys.platform.startswith('win'):
-        if not bool(SystemTrayApp.windowsDarkMode()):
+        if not bool(SystemTrayApp.windowsLightMode()):
             iconFile = 'taskBarLight.png'
     tray = SystemTrayApp(QIcon(getPath(iconFile)), MainWindow)
     window.setupUi(MainWindow)


### PR DESCRIPTION
**What**? Set icon color to light if dark mode
**Why**? Hard to find icon
**Fix**? Added helper method `SystemTrayApp.windowsLightMode()` 🤷‍♂️ -> used in check similar to MacOS

This would make dark mode better for GUI:

- [ ] Sync taskbar icon w/ OS theme / keep it up to date (check periodically)
- [ ] Add setting to sync GUI theme w/ OS (instead of only dark mode on/off)