### PR TITLE
Windows fix for Documents folder not being in the default location.

### DIFF
--- a/client/app.py
+++ b/client/app.py
@@ -114,7 +114,23 @@ def timeSince(epoch:int):
         else:
             break
     return 'Last online %s %s%s ago' % (int(offset), unit, ('' if int(offset) == 1 else 's'))
-settingsFile = os.path.expanduser('~/Documents/NSO-RPC/settings.txt')
+def getAppPath():
+    applicationPath = os.path.expanduser('~/Documents/NSO-RPC')
+    # Windows allows you to move your UserProfile subfolders, Such as Documents, Videos, Music etc.
+    # However os.path.expanduser does not actually check and assumes its in the default location.
+    # This tries to correctly resolve the Documents path and fallbacks to default if it fails.
+    if os.name == 'nt':
+        try:
+            import ctypes.wintypes
+            CSIDL_PERSONAL = 5 # My Documents
+            SHGFP_TYPE_CURRENT = 0 # Get current, not default value
+            buf=ctypes.create_unicode_buffer(ctypes.wintypes.MAX_PATH)
+            ctypes.windll.shell32.SHGetFolderPathW(None, CSIDL_PERSONAL, None, SHGFP_TYPE_CURRENT, buf)
+            applicationPath = os.path.join(buf.value,'NSO-RPC')
+        except:pass
+    return applicationPath
+applicationPath = getAppPath()
+settingsFile = os.path.join(applicationPath,'settings.txt')
 settings = {
     'dark': False,
 }
@@ -387,7 +403,7 @@ class GUI(Ui_MainWindow):
             client.api.targetID = userSelected
         else:
             client.api.targetID = None
-        with open(os.path.join(os.path.expanduser('~/Documents/NSO-RPC'), 'private.txt'), 'w') as file:
+        with open(os.path.join(applicationPath, 'private.txt'), 'w') as file:
             file.write(json.dumps({
                 'session_token': client.api.session_token,
                 'user_lang': client.api.user_lang,


### PR DESCRIPTION
Windows allows you to move/store a users subfolders, such as Documents in a different location, This could be another hard drive to make reinstalling not as tedious. 
![explorer_3INTsJl4U0](https://user-images.githubusercontent.com/17028801/199367676-5be94dae-3b7c-4c6b-977f-dd67992cda10.png)
The below code however assumes that these are only stored in the default location, such as `C:\Users\Username`.
```py
os.path.expanduser('~/Documents/NSO-RPC')
```
This commit resolves this by wrapping the path in a `getAppPath()` function, and attempting to get the path from Windows and falling back on the above method if it fails or not on windows.

Attempting to use the Default location can cause strange behavioural issues in windows, depending on how the locations were setup. as well as how the application handles it.

---
I also believe this could have affected #10 however this issue is stale and I haven't tested Windows 11

Edit: This PR should resolve errors such as 
![vmconnect_ipqU8ZLmMW](https://user-images.githubusercontent.com/17028801/199369730-d2224cf4-fcc7-4730-a3a7-9e8d5f40e11b.png)
