### PR TITLE
Hotfix apple version regex

### DIFF
--- a/client/api/__init__.py
+++ b/client/api/__init__.py
@@ -45,6 +45,10 @@ def getVersion():
             log('Failed to get Apple\'s store page. Retrying...')
     searchPattern = re.compile(r'Version\s(\d\.\d\.\d)*')
     version = searchPattern.findall(r.text)
+    if len(version[0]) == 0:
+        # Apple seems to have two spaces now before version number, this catches the edge case if this is just a temp fix.
+        searchPattern = re.compile(r'Version \s(\d\.\d\.\d)*')
+        version = searchPattern.findall(r.text) 
     if version == []:
         return ''
     pattern = re.compile(r'(\d.\d.\d)')


### PR DESCRIPTION
Apple seems to have changed the HTML for the version, where it has two spaces now before the version number. This may be a bug on their side however it does break our current version regex, so this adds a fallback to handle this extra space if the first method fails. 
Below is the snippet showing the html

```html
        <div class="l-column small-12 medium-3 large-4 small-valign-top whats-new__latest">
          <div class="l-row">
            <time data-test-we-datetime datetime="2022-12-01T00:00:00.000Z" aria-label="December 1, 2022" class="" >Dec 1, 2022</time>
            <p class="l-column small-6 medium-12 whats-new__latest__version">Version  2.4.0</p>
          </div>
        </div>
```