### PR TITLE
Fix regex for detecting mobile app version number

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ test*.*
 
 # MacOS
 .DS_Store
+/.vs

--- a/client/api/__init__.py
+++ b/client/api/__init__.py
@@ -43,7 +43,7 @@ def getVersion():
             break
         except:
             log('Failed to get Apple\'s store page. Retrying...')
-    searchPattern = re.compile(r'Version\s(\d\.\d\.\d)*')
+    searchPattern = re.compile(r'Version\s*(\d\.\d\.\d)+')
     version = searchPattern.findall(r.text)
     if version == []:
         return ''


### PR DESCRIPTION
Possible for for issue #54.

Adding `*` to `Version\s` will match multiple whitespace characters e.g. 
```
Version  2.4.0
```

Adding `+` at the end forces the regex to match at least one version number string, which excludes cases like
```
Version foobar
```
