### PR TITLE
Pin pyinstaller-hooks-contrib to fix Requests v2.28.2 dependency 

### DIFF
--- a/client/requirements.txt
+++ b/client/requirements.txt
@@ -2,3 +2,5 @@ requests
 pypresence
 pyqt5
 qtwidgets
+
+pyinstaller-hooks-contrib>=2022.15


### PR DESCRIPTION
**Update: This has been fixed via: https://github.com/pyinstaller/pyinstaller-hooks-contrib/issues/534 and was in fact an issue with PyInstaller, I've done the correct fix and replaced the commit.**
---
Requests has released [v2.28.2](https://github.com/psf/requests/releases/tag/v2.28.2) that added support for charset_normalizer 3.x, However it seems to be causing build issues when the application is built and also trying to use chardet (An alternative to charset_normalizer), the application is meant to detect and decide what one to use, however failing with PyInstaller.

~~Forcing charset_normalizer to 2.x seems to fix the issue, however this may only be a temporary change.~~

Note: The environment that triggers this issue seems semi-random. However I was able to replicate it on a fresh windows vm, however not a fresh PIP & Python environment.



```py
Traceback (most recent call last):
  File "requests\compat.py", line 11, in <module>
ModuleNotFoundError: No module named 'chardet'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "app.py", line 9, in <module>
  File "PyInstaller\loader\pyimod02_importers.py", line 499, in exec_module
  File "requests\__init__.py", line 45, in <module>
  File "PyInstaller\loader\pyimod02_importers.py", line 499, in exec_module
  File "requests\exceptions.py", line 9, in <module>
  File "PyInstaller\loader\pyimod02_importers.py", line 499, in exec_module
  File "requests\compat.py", line 13, in <module>
  File "PyInstaller\loader\pyimod02_importers.py", line 499, in exec_module
  File "charset_normalizer\__init__.py", line 24, in <module>
  File "PyInstaller\loader\pyimod02_importers.py", line 499, in exec_module
  File "charset_normalizer\api.py", line 5, in <module>
  File "PyInstaller\loader\pyimod02_importers.py", line 499, in exec_module
  File "charset_normalizer\cd.py", line 9, in <module>
ModuleNotFoundError: No module named 'charset_normalizer.md__mypyc'
```

![QfMtulN8pHb2lZce](https://user-images.githubusercontent.com/17028801/212169619-276490a4-1159-4f5a-a9b8-bf2f8f15b9ed.png)
