### PR TITLE
Add "qtpy" to requirements.txt

### DIFF
--- a/client/requirements.txt
+++ b/client/requirements.txt
@@ -1,6 +1,7 @@
 requests
 pypresence
 pyqt5
+qtpy
 qtwidgets
 
 pyinstaller-hooks-contrib>=2022.15


### PR DESCRIPTION
Fix #60 

Ubuntu seems to be using their own build of python, aswell as Python3-PyQt5, This seems to cause weird behaviour, most likely due to weird edge cases and ubuntu's version of PyQt5 seems to expect qtpy to exist due to it being an abstraction layer.

Adding this requirement fixes Ubuntu 22.04 and does not affect the windows build and both have been tested working with this change.