### PR TITLE
python3-pip is required on newer versions of ubuntu

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -12,8 +12,14 @@ function checkDir {
   fi
 }
 
+# Only try and install pip if its missing
+if pip --version &>/dev/null; then
+  sudo apt-get install python3-pyqt5
+else
+  sudo apt-get install python3-pyqt5 python3-pip
+fi
+
 cd ../client
-sudo apt-get install python3-pyqt5
 python3 -m pip install -r requirements.txt
 
 executableDir='/opt/NSO-RPC/'


### PR DESCRIPTION
python3-pip is not installed by default with newer versions of Debian/Ubuntu out of the box.
This PR installs python3-pip only **if the user does not already have a working pip environment**.
This should in theory help prevent breaking custom pip local user installations.