### PR TITLE
Fix and lock the packages for building NSO-RPC

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,0 +1,56 @@
+name: 'Build NSO-RPC'
+on:
+  release:
+    types: [released]
+
+jobs:
+  build:
+    name: 'Build NSO-RPC'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ['windows-latest', 'ubuntu-latest', 'macos-latest']
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.10.11
+
+    # Windows Build 
+    - name: "Build"
+      if: matrix.os == 'windows-latest'
+      run: cd scripts && ./build.bat
+    
+    - name: "Upload Build"
+      if: matrix.os == 'windows-latest'
+      uses: softprops/action-gh-release@v0.1.15
+      with:
+        files: client/dist/NSO-RPC.exe
+
+    # Linux Build
+    - name: "Copy install.sh to linux.sh"
+      if: matrix.os == 'ubuntu-latest'
+      run: cp scripts/install.sh scripts/linux.sh
+
+    - name: "Upload script"
+      if: matrix.os == 'ubuntu-latest'
+      uses: softprops/action-gh-release@v0.1.15
+      with:
+        files: scripts/linux.sh
+
+
+    # MacOS Build
+    - name: "Build"
+      if: matrix.os == 'macos-latest'
+      run: |
+        cd scripts &&
+        ./build.sh &&
+        cd ../client/dist &&
+        zip -yr mac.zip NSO-RPC.app/
+
+    - name: "Upload Build"
+      if: matrix.os == 'macos-latest'
+      uses: softprops/action-gh-release@v0.1.15
+      with:
+        files: client/dist/mac.zip

--- a/client/app.py
+++ b/client/app.py
@@ -227,6 +227,31 @@ class GUI(Ui_MainWindow):
                     os.system('systemctl --user disable NSO-RPC.service')
                     os.remove(os.path.join(linuxServicePath, "NSO-RPC.service"))
                     os.system('systemctl --user daemon-reload')
+            elif platform.system() == "Darwin":
+                applicationPath = os.path.join(os.path.normpath(os.getcwd() + os.sep + os.pardir), "MacOS/NSO-RPC")
+                macOSplist = [
+                        '<?xml version="1.0" encoding="UTF-8"?>',
+                        '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">',
+                        '<plist version="1.0">',
+                        '	<dict>',
+                        '		<key>Label</key>',
+                        '		<string>NSO-RPC.app</string>',
+                        '		<key>Program</key>',                       
+                        '		<string>'+applicationPath+'</string>',
+                        '		<key>RunAtLoad</key>',
+                        '		<true/>',
+                        '	</dict>',
+                        '</plist>'
+                ]
+                macOSLaunchAgentPath = os.path.expanduser('~/Library/LaunchAgents')
+                if not os.path.exists(macOSLaunchAgentPath):
+                    os.makedirs(macOSLaunchAgentPath)
+                if settings['startOnLaunch'] == False:
+                    with open(os.path.join(macOSLaunchAgentPath, "NSO-RPC.plist"),'w') as out:
+                        out.writelines(line + "\n" for line in macOSplist)
+                        out.close()
+                else:
+                    os.system('rm '+ os.path.join(macOSLaunchAgentPath, "NSO-RPC.plist"))
             else:
                 raise Exception('not implemented yet')
             settings['startOnLaunch'] = mode
@@ -326,11 +351,6 @@ class GUI(Ui_MainWindow):
         self.startInSystemTray.setGeometry(QRect(101,120,60,41))
         self.startOnLaunch = AnimatedToggle(self.page_3, checked_color = '#09ab44')
         self.startOnLaunch.setGeometry(QRect(101,160,60,41))
-
-        # Prevent showing autostart option on MacOS as its currently unsupported
-        if platform.system() == "Darwin":
-            self.startOnLaunch.setHidden(True)
-            self.label_19.setHidden(True)
 
     def closeEvent(self, event = None):
         if self.mode == 1:

--- a/client/requirements.txt
+++ b/client/requirements.txt
@@ -4,4 +4,6 @@ pyqt5
 qtpy
 qtwidgets
 
-pyinstaller-hooks-contrib>=2022.15
+pyinstaller==5.10.1
+charset_normalizer<3.0
+pyinstaller-hooks-contrib==2023.2


### PR DESCRIPTION
The following issue with PR #59 showed up again, I tried updating the hooks but the issue still occurs, Their seemed to mainly be an issue with MacOS and the universal2 builds.

Locking `charset_normalizer` to v2 fixes this and hopefully by locking these three packages stop this occurring again for awhile, but a better fix may be needed in the future.