### PR TITLE
Fix and lock the packages for building NSO-RPC

### DIFF
--- a/client/requirements.txt
+++ b/client/requirements.txt
@@ -4,4 +4,6 @@ pyqt5
 qtpy
 qtwidgets
 
-pyinstaller-hooks-contrib>=2022.15
+pyinstaller==5.10.1
+charset_normalizer<3.0
+pyinstaller-hooks-contrib==2023.2


### PR DESCRIPTION
The following issue with PR #59 showed up again, I tried updating the hooks but the issue still occurs, Their seemed to mainly be an issue with MacOS and the universal2 builds.

Locking `charset_normalizer` to v2 fixes this and hopefully by locking these three packages stop this occurring again for awhile, but a better fix may be needed in the future.