### PR TITLE
Add Github Actions

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -17,11 +17,11 @@ jobs:
       with:
         python-version: 3.10.11
 
-    # Windows Build 
+    # Windows Build
     - name: "Build"
       if: matrix.os == 'windows-latest'
       run: cd scripts && ./build.bat
-    
+
     - name: "Upload Build"
       if: matrix.os == 'windows-latest'
       uses: softprops/action-gh-release@v0.1.15
@@ -43,14 +43,14 @@ jobs:
         cd scripts &&
         ./build.sh &&
         cd ../client/dist &&
-        zip -yr mac-portable.zip NSO-RPC.app/ &&
-        productbuild --component NSO-RPC.app /Applications NSO-RPC.pkg &&
-        zip -yr mac-installer.zip NSO-RPC.pkg
+        ln -s /Applications "Applications (admin)" &&
+        hdiutil create -fs HFS+ -srcfolder . -volname NSO-RPC mac-installer.dmg &&
+        zip -yr mac-portable.zip NSO-RPC.app/
 
     - name: "Upload Build"
       if: matrix.os == 'macos-latest'
       uses: softprops/action-gh-release@v0.1.15
       with:
         files: |
-          client/dist/mac-installer.zip
+          client/dist/mac-installer.dmg
           client/dist/mac-portable.zip

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,0 +1,60 @@
+name: 'Build NSO-RPC'
+on:
+  release:
+    types: [released]
+
+jobs:
+  build:
+    name: 'Build NSO-RPC'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ['windows-latest', 'ubuntu-latest', 'macos-latest']
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.10.11
+
+    # Windows Build 
+    - name: "Build"
+      if: matrix.os == 'windows-latest'
+      run: cd scripts && ./build.bat
+    
+    - name: "Upload Build"
+      if: matrix.os == 'windows-latest'
+      uses: softprops/action-gh-release@v0.1.15
+      with:
+        files: client/dist/NSO-RPC.exe
+
+    # Linux Build
+    - name: "Copy install.sh to linux.sh"
+      if: matrix.os == 'ubuntu-latest'
+      run: cp scripts/install.sh scripts/linux.sh
+
+    - name: "Upload script"
+      if: matrix.os == 'ubuntu-latest'
+      uses: softprops/action-gh-release@v0.1.15
+      with:
+        files: scripts/linux.sh
+
+
+    # MacOS Build
+    - name: "Build"
+      if: matrix.os == 'macos-latest'
+      run: |
+        cd scripts &&
+        ./build.sh &&
+        cd ../client/dist &&
+        zip -yr mac-portable.zip NSO-RPC.app/ &&
+        productbuild --component NSO-RPC.app /Applications NSO-RPC.pkg &&
+        zip -yr mac-installer.zip NSO-RPC.pkg
+
+    - name: "Upload Build"
+      if: matrix.os == 'macos-latest'
+      uses: softprops/action-gh-release@v0.1.15
+      with:
+        files: |
+          client/dist/mac-installer.zip
+          client/dist/mac-portable.zip

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -29,10 +29,6 @@ jobs:
         files: client/dist/NSO-RPC.exe
 
     # Linux Build
-    - name: "Copy install.sh to linux.sh"
-      if: matrix.os == 'ubuntu-latest'
-      run: cp scripts/install.sh scripts/linux.sh
-
     - name: "Upload script"
       if: matrix.os == 'ubuntu-latest'
       uses: softprops/action-gh-release@v0.1.15

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,7 +1,7 @@
 name: 'Build NSO-RPC'
 on:
   release:
-    types: [released]
+    types: [published]
 
 jobs:
   build:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -12,8 +12,8 @@ jobs:
       matrix:
         os: ['windows-latest', 'ubuntu-latest', 'macos-latest']
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v3
       with:
         python-version: 3.10.11
 

--- a/scripts/linux.sh
+++ b/scripts/linux.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# This is intended for Ubuntu Linux
+# although it may work for other distributions
+# Please contact me if this fails
+#
+
+if [ ! -d './NSO-RPC' ]
+then
+    git clone 'https://github.com/MCMi460/NSO-RPC'
+fi
+
+cd './NSO-RPC/scripts'
+chmod +x './install.sh'
+./install.sh


### PR DESCRIPTION
<ins>**This needs #68 or the macOS build will be broken!**</ins>

---
This PR adds auto building for NSO-RPC via GitHub Actions, I've tested all 3 builds and they seem to work correctly, however NSO-RPC's mac build still needs tested on an m1 mac, but I believe it should work without an issue due to Rosetta 2.

This does not currently set the release notes, however it does not set these and only adds the files as their build, so that is currently needed to be done manually.

This also changes how NSO-RPC is build on mac slightly. This changes the original `mac.zip` to `mac-portable.zip`, as I've added an installable version of NSO-RPC via productbuild and that's known as `mac-installer.zip`, More details about my reasoning below.

---

This is mainly useful because for #66, this PR isn't needed for it to work, however if NSO-RPC is set to autorun from the downloads folder, it will usually not work due to being in a security folder instead of a normal one. 

However if moved to another folder, such as desktop it works without issues.

TLDR:
- mac-portable autostart works if <ins>**not running**</ins> from the downloads folder.
- mac-installer will install NSO-RPC in /Applications and thus autostart works correctly.

Note: the installer is just a packaged version of the portable that's simply installed into /Applications

---

Extra Note: I could have probably cleaned up the Github action little more, however I wanted to try and keep it simple and at most would have just removed the skip's when looking at the individual builds, however that's just visual.