### PR TITLE
[Fixed PR] Add na_id and fix hash_method header.

### DIFF
--- a/client/api/__init__.py
+++ b/client/api/__init__.py
@@ -210,14 +210,15 @@ class UsersMe():
         return json.loads(response.text)
 
 class imink():
-    def __init__(self, id_token, timestamp, guid, iteration):
+    def __init__(self, na_id, id_token, timestamp, guid, iteration):
         self.headers = {
             'User-Agent': 'NSO-RPC/%s' % version,
             'Content-Type': 'application/json; charset=utf-8',
         }
         self.body = {
             'token': id_token,
-            'hashMethod': str(iteration),
+            'hash_method': str(iteration),
+            'na_id': na_id,
         }
 
         self.url = 'https://api.imink.app'
@@ -250,8 +251,9 @@ class Login():
 
         self.userInfo = userInfo
         self.accessToken = accessToken
+        self.na_id = userInfo['id']
 
-        self.imink = imink(self.accessToken, self.timestamp, self.guid, 1).get()
+        self.imink = imink(self.na_id, self.accessToken, self.timestamp, self.guid, 1).get()
         self.timestamp = int(self.imink['timestamp'])
         self.guid = self.imink['request_id']
 


### PR DESCRIPTION
Recently their was a change that broke Nintendo f-generation, This has mostly been fixed however theirs still some downtime issues with imink, that may need extra attempts before failing.

However this PR adds the na_id that is recommended to be send now for the new f-generation, and I believe I've implemented it correctly, These changes are noted here: https://github.com/samuelthomas2774/nxapi/discussions/10#discussioncomment-5995498

Note, NSO-RPC does in fact currently work again, however this is more future proofing.

I also noticed when doing this that hashMethod got changed awhile ago, and its meant to be hash_method, however the old way was still supported, so i decided to update the header.

Edit: I remade the PR because I noticed a issue with the previous one, and i had to rewrite the commit.