### PR TITLE
Add run as admin suggestion for Windows

### DIFF
--- a/client/app.py
+++ b/client/app.py
@@ -243,7 +243,7 @@ class GUI(Ui_MainWindow):
                         '	<dict>',
                         '		<key>Label</key>',
                         '		<string>NSO-RPC.app</string>',
-                        '		<key>Program</key>',                       
+                        '		<key>Program</key>',
                         '		<string>'+applicationPath+'</string>',
                         '		<key>RunAtLoad</key>',
                         '		<true/>',
@@ -437,14 +437,7 @@ class GUI(Ui_MainWindow):
         self.startOnLaunch.setChecked(settings.get('startOnLaunch', False))
         self.startOnLaunch.toggled.connect(self.setLaunchMode)
 
-        # This just assumes that if client.rpc is set to None, that their was a permission issue preventing NSO-RPC.
-        # Their was an attempt at catching the [Access is denied] event in the cli, however i had scope and timing issues with it.
-        # We also assume that only Windows users would experence this permission oversight.
-        if not client.rpc and platform.system() == 'Windows':
-            self.label_12.setFixedWidth(self.label_12.width()+120)
-            self.label_12.setFixedHeight(self.label_12.height()+15)
-            self.label_12.setText("<a style='color: orange;'>Unable to connect to Discord,<br>Try running NSO-RPC with Administrator.</a>")
-            self.toggleDiscord.setHidden(True)
+        self.checkDiscordError()
 
         # Set home
         self.switchMe()
@@ -522,6 +515,29 @@ class GUI(Ui_MainWindow):
         self.presenceState.adjustSize()
 
         userSelected = user.nsaId
+
+    def checkDiscordError(self):
+        print('test')
+        # This just assumes that if client.rpc is set to None, then there was a permission issue preventing NSO-RPC.
+        # There was an attempt at catching the [Access is denied] event in the cli, however I had scope and timing issues with it.
+        # We also assume that only Windows users would experence this permission oversight.
+        # Updated by MCMi460 -- works for Admin issues as well as Discord is not running issues.
+        if not client.rpc:
+            ret = client.connect()
+            if not ret[0]:
+                msg = ''
+                if 'WinError 5' in str(ret[1]):
+                    msg = 'Try running NSO-RPC with Administrator.'
+                elif 'Could not find Discord' in str(ret[1]):
+                    msg = 'Try opening Discord first.'
+                self.label_12.setFixedWidth(self.label_12.width()+120)
+                self.label_12.setFixedHeight(36)
+                self.label_12.setText("<a style='color: orange;'>Unable to connect to Discord!<br>%s</a>" % msg)
+                self.toggleDiscord.setHidden(True)
+        else:
+            self.toggleDiscord.setHidden(False)
+            self.label_12.setFixedHeight(21)
+            self.label_12.setText('Discord:')
 
     def updateProfile(self, new):
         if new:
@@ -630,6 +646,7 @@ class GUI(Ui_MainWindow):
         self.stackedWidget_2.setCurrentIndex(1)
 
     def switchSettings(self):
+        self.checkDiscordError()
         self.stackedWidget_2.setCurrentIndex(2)
 
     def openPfp(self, event = None):

--- a/client/app.py
+++ b/client/app.py
@@ -437,6 +437,15 @@ class GUI(Ui_MainWindow):
         self.startOnLaunch.setChecked(settings.get('startOnLaunch', False))
         self.startOnLaunch.toggled.connect(self.setLaunchMode)
 
+        # This just assumes that if client.rpc is set to None, that their was a permission issue preventing NSO-RPC.
+        # Their was an attempt at catching the [Access is denied] event in the cli, however i had scope and timing issues with it.
+        # We also assume that only Windows users would experence this permission oversight.
+        if not client.rpc and platform.system() == 'Windows':
+            self.label_12.setFixedWidth(self.label_12.width()+120)
+            self.label_12.setFixedHeight(self.label_12.height()+15)
+            self.label_12.setText("<a style='color: orange;'>Unable to connect to Discord,<br>Try running NSO-RPC with Administrator.</a>")
+            self.toggleDiscord.setHidden(True)
+
         # Set home
         self.switchMe()
 

--- a/client/cli.py
+++ b/client/cli.py
@@ -13,7 +13,7 @@ class Discord():
     def __init__(self, session_token = None, user_lang = None, rpc = False, targetID = None, version = None):
         self.rpc = None
         if rpc:
-            if not self.connect():
+            if not self.connect()[0]:
                 sys.exit("Failed to connect to Discord")
         self.running = False
         self.api = None
@@ -38,9 +38,9 @@ class Discord():
     def connect(self):
         try:
             self.rpc = pypresence.Presence('637692124539650048')
-        except:
+        except Exception as e:
             self.rpc = None
-            return False
+            return (False, e)
         fails = 0
         while True:
             # Attempt to connect to Discord. Will wait until it connects
@@ -52,9 +52,9 @@ class Discord():
                 if fails > 500:
                     print(log('Error, failed after 500 attempts\n\'%s\'' % e))
                     self.rpc = None
-                    return False
+                    return (False, e)
                 continue
-        return True
+        return (True,)
 
     def disconnect(self):
         if self.rpc:


### PR DESCRIPTION
If you are running Discord as administrator, NSO-RPC will fail to connect to the discord IPC pipe due to windows permissions.

I attempted to catch the `'[WinError 5] Access is denied'` exception at [client/cli.py#L50-L56](https://github.com/MCMi460/NSO-RPC/blob/main/client/cli.py#L50-L56), as it returns an IOError exception, however I had multiple timing and scope(?) issues around that, even trying to add handler and extra stuff around a simple boolean had consistency issues, reporting not connected to discord, then afterwards saying we are fine etc.

This solution's main issue is that its assuming on windows, the only reason for NSO-RPC to have issues connecting to discord is because Discord is running with Admin privileges.

**Note: This will give a false positive telling the user to try running NSO-RPC with Admin if Discord is not running.**
