### PR TITLE
Fix System tray support on Linux

### DIFF
--- a/client/app.py
+++ b/client/app.py
@@ -15,6 +15,7 @@ from cli import *
 # PyQt5 Initialization
 app = QApplication(sys.argv)
 app.setQuitOnLastWindowClosed(False)
+app.setApplicationName("NSO-RPC")
 MainWindow = QMainWindow()
 # NSO Variables
 session_token, user_lang, targetID = getToken(False)
@@ -211,6 +212,7 @@ class GUI(Ui_MainWindow):
                         "[Service]",
                         "Type=simple",
                         "StandardOutput=journal",
+                        "WorkingDirectory="+os.getcwd(),
                         "ExecStart="+" ".join([sys.executable, os.path.abspath(__file__)]),
                         "",
                         "[Install]",


### PR DESCRIPTION
This fixes both the icon missing from the system try if launched via the service file, aswell as fixes the app name so its "NSO-RPC" instead of "app.py"