### PR TITLE
build: build a universal2 binary

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,5 +2,8 @@ cd ../client
 python3 -m pip install -r requirements.txt py2app
 py2applet --make-setup app.py icon.icns "icon.png" "taskbarDark.png" "taskbarLight.png"
 sed -i '' -e "s/)/    name='NSO-RPC')/" setup.py
-python3 setup.py py2app -O2
+# build universal binary
+python3 setup.py py2app -O2 --arch=universal2
+# arm64 requires codesigning to run
+codesign --deep --force --sign - dist/NSO-RPC.app/Contents/MacOS/*
 open dist


### PR DESCRIPTION
This improves performance and battery life on apple silicon macs as it doesn't need to emulate x86_64, also it still is compatible with intel macs