### PR TITLE
Python 3.10.11 -> 3.11.4

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v3
       with:
-        python-version: 3.10.11
+        python-version: 3.11.4
 
     # Windows Build
     - name: "Build"
@@ -65,11 +65,11 @@ jobs:
     - uses: actions/checkout@v3
 
     # MacOS Build
-    - name: "Install Python 3.10.11 and build NSO-RPC"
+    - name: "Install Python 3.11.4 and build NSO-RPC"
       run: |
-        curl https://www.python.org/ftp/python/3.10.11/python-3.10.11-macos11.pkg -o python-3.10.11-macos11.pkg
-        sudo installer -verbose -pkg python-3.10.11-macos11.pkg -target / &&
-        python3.10 -m pip install PyQt6 &&
+        curl https://www.python.org/ftp/python/3.11.4/python-3.11.4-macos11.pkg -o python-3.11.4-macos11.pkg
+        sudo installer -verbose -pkg python-3.11.4-macos11.pkg -target / &&
+        python3.11 -m pip install PyQt6 &&
         cd scripts/macos-universal2 &&
         bash ./build.sh &&
         python3 debloat-qt.py &&

--- a/scripts/build.bat
+++ b/scripts/build.bat
@@ -30,7 +30,7 @@ if "%PYQT_PACKAGE%"=="" (
 echo Building with %PYQT_PACKAGE%
 
 REM Install requirements
-python -m pip install -r ./requirements.txt pypiwin32 winshell pyinstaller==5.10.1 pyinstaller-hooks-contrib==2023.2
+python -m pip install -r ../client/requirements.txt pypiwin32 winshell pyinstaller>=5.12 pyinstaller-hooks-contrib==2023.4
 
 REM Build the executable using PyInstaller
 python -m PyInstaller --onefile --clean --noconsole --exclude-module autopep8 --noupx --add-data "*.png;." --icon=icon.ico --name=NSO-RPC ..\client\app.py

--- a/scripts/macos-universal2/prep-PyQt.sh
+++ b/scripts/macos-universal2/prep-PyQt.sh
@@ -2,7 +2,7 @@
 # Provided by @spotlightishere on Github
 # https://github.com/MCMi460/NSO-RPC/pull/86#issuecomment-1605700512
 
-alias python3=python3.10
+alias python3=python3.11
 
 # Download and unpack
 python3 -m pip download --only-binary=:all: --platform=macosx_13_0_x86_64 PyQt6_Qt6
@@ -28,5 +28,5 @@ export -f merge_frameworks
 find universal -perm +111 -type f -exec sh -c 'merge_frameworks "$1"' _ {} \;
 python3 -m wheel pack universal/PyQt6_*
 
-# Finally, install our universal python3.10 -m wheel.
+# Finally, install our universal python3.11 -m wheel.
 python3 -m pip install PyQt6_*universal2.whl --force-reinstall


### PR DESCRIPTION
Updates Python from 3.10 to 3.11, as 3.10 is only receiving bug fixes.

- Fixes a typo I missed with the build.bat script due to the path being wrong 
- Update PyInstaller due to : https://github.com/pyinstaller/pyinstaller/issues/7692

An unintended feature of this PR is that the universal2 build seems to be around 20MB~ Bigger, rather than try and figure it out, i think its better to take the slightly larger size for an up-to-date python.