### PR TITLE
Force x86_64 on non-universal2 builds

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,5 +2,5 @@ cd ../client
 python3 -m pip install -r requirements.txt py2app
 py2applet --make-setup app.py icon.icns "icon.png" "taskbarDark.png" "taskbarLight.png"
 sed -i '' -e "s/)/    name='NSO-RPC')/" setup.py
-python3 setup.py py2app -O2
+python3 setup.py py2app --arch=x86_64 -O2
 open dist


### PR DESCRIPTION
I don't believe this will fix the issue from #91, as I believe this is always going to happen for m1 users not using the universal2 build in the future due to the differences on how Qt6 is bundled with the app.

However the issue with the x64 build including arm64/universal2 build is believed to be caused by #90, So this just prevents arm64 being included on the x64 build that uses a different build.sh file.