### PR TITLE
Add overrideVersion for f-token generation

### DIFF
--- a/client/app.py
+++ b/client/app.py
@@ -174,6 +174,7 @@ try:
 except:
     versionTag = ['', '']
 
+
 def writeSettings():
     try:
         os.mkdir(os.path.dirname(settingsFile))
@@ -189,6 +190,7 @@ def readSettings():
         all = json.loads(file.read())
     for key in all.keys():
         settings[key] = all.get(key)
+
 
 friendTime = time.time()
 iconsStorage = {}
@@ -326,7 +328,7 @@ class GUI(Ui_MainWindow):
             if len(friendcode) != 12:
                 raise Exception()
             friendcode = int(friendcode)
-            friendcode = 'SW-' + '-'.join([str(friendcode)[i:i+4] for i in range(0, 12, 4)])
+            friendcode = 'SW-' + '-'.join([str(friendcode)[i:i + 4] for i in range(0, 12, 4)])
         except:
             dlg = QMessageBox()
             dlg.setWindowTitle('NSO-RPC')
@@ -815,6 +817,11 @@ if __name__ == '__main__':
         writeSettings()
     client.smallImagePFP = settings['smallImagePFP']
     client.friendcode = settings['friendcode']
+
+    # Override version if overrideVersion is set in settings
+    if settings.get('overrideVersion') is not None:
+        print(log("Version override Detected: Replacing target version {} with {}".format(version, settings['overrideVersion'])))
+        version = settings['overrideVersion']
 
     window = GUI(MainWindow)
 


### PR DESCRIPTION
This allows you to override the version used for f-token generation, where in some cases the new tokens don't work but the previous ones do.

This is a more easier way to override the version rather than overriding and rebuilding for "temp fixes", while a previous versions tokens are still valid for NSO-RPC.

Ideally this would have a GUI element, however the way NSO-RPC is structured currently makes this harder to implement.