### PR TITLE
Multiple small tweaks and fixes

### DIFF
--- a/client/api/__init__.py
+++ b/client/api/__init__.py
@@ -46,6 +46,11 @@ def getAppPath():
     return portable_data_path if os.path.isdir(portable_data_path) else application_path
 
 
+def Restart_NSORPC():
+    args = [sys.executable] + sys.argv
+    os.execl(sys.executable, *args)
+
+
 def log(info, time = time.time()):
     path = getAppPath()
     if not os.path.isdir(path):

--- a/client/app.py
+++ b/client/app.py
@@ -651,8 +651,9 @@ class GUI(Ui_MainWindow):
             }))
         dlg = QMessageBox()
         dlg.setWindowTitle('NSO-RPC')
-        dlg.setText('You will need to restart the application in order for the changes to take place.\nSorry for the inconvenience.')
-        sys.exit(dlg.exec_())
+
+        # Restart NSO-RPC to apply changes
+        Restart_NSORPC()
 
     def setFriendIcons(self, layout):
         global client, iconsStorage

--- a/client/app.py
+++ b/client/app.py
@@ -174,6 +174,7 @@ try:
 except:
     versionTag = ['', '']
 
+
 def writeSettings():
     try:
         os.mkdir(os.path.dirname(settingsFile))
@@ -189,6 +190,7 @@ def readSettings():
         all = json.loads(file.read())
     for key in all.keys():
         settings[key] = all.get(key)
+
 
 friendTime = time.time()
 iconsStorage = {}
@@ -326,7 +328,7 @@ class GUI(Ui_MainWindow):
             if len(friendcode) != 12:
                 raise Exception()
             friendcode = int(friendcode)
-            friendcode = 'SW-' + '-'.join([str(friendcode)[i:i+4] for i in range(0, 12, 4)])
+            friendcode = 'SW-' + '-'.join([str(friendcode)[i:i + 4] for i in range(0, 12, 4)])
         except:
             dlg = QMessageBox()
             dlg.setWindowTitle('NSO-RPC')
@@ -815,6 +817,11 @@ if __name__ == '__main__':
         writeSettings()
     client.smallImagePFP = settings['smallImagePFP']
     client.friendcode = settings['friendcode']
+
+    # Override version if overrideVersion is set in settings
+    if settings.get('overrideVersion') is not None:
+        print(log("Version override Detected: Replacing target version {} with {}".format(version, settings['overrideVersion'])))
+        version = settings['overrideVersion']
 
     window = GUI(MainWindow)
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -219,6 +219,7 @@ mkdir -p "$iconDir"
 
 sudo cp './icon.svg' "$iconDir/nso.svg"
 
+# Determine the Python executable
 PYTHON_EXECUTABLE="/opt/NSO-RPC/venv/bin/python"
 if [ "$NO_VENV" = true ]; then
     PYTHON_EXECUTABLE="python3"
@@ -230,7 +231,7 @@ Type=Application
 Name=Nintendo Switch Online Rich Presence
 GenericName=NSO-RPC
 Comment=Display your Nintendo Switch game status on Discord!
-Exec=/bin/sh -c '. /opt/NSO-RPC/venv/bin/activate && cd /opt/NSO-RPC && exec $PYTHON_EXECUTABLE app.py'
+Exec=/bin/sh -c 'cd /opt/NSO-RPC && exec $PYTHON_EXECUTABLE /opt/NSO-RPC/app.py'
 Icon=nso.svg
 Terminal=false
 Categories=Game;Application;Utility;

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -21,6 +21,23 @@ function is_package_installed {
     fi
 }
 
+# Parse command-line options
+NO_VENV=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --no-venv)
+        NO_VENV=true
+        shift
+        ;;
+    *)
+        echo "Unknown option: $1"
+        exit 1
+        ;;
+    esac
+done
+
+
 # Set the package manager command based on availability
 for pkg_manager in "${PACKAGE_MANAGERS[@]}"; do
     if command -v "$pkg_manager" &>/dev/null; then
@@ -40,9 +57,29 @@ echo -e "${YELLOW}[NSO-RPC: Installer] Using $PACKAGE_MANAGER package manager.${
 
 # Check if pip is installed
 if ! is_package_installed pip; then
-    sudo $PACKAGE_MANAGER install -y python3-pip
+    case "$PACKAGE_MANAGER" in
+        "apt-get" | "dnf")
+            sudo $PACKAGE_MANAGER install -y python3-pip
+            ;;
+        "pacman")
+            sudo $PACKAGE_MANAGER -S --noconfirm python-pip
+            ;;
+        *)
+            echo -e "${RED}[NSO-RPC: Installer] Unsupported package manager.${RESET}"
+            exit 1
+            ;;
+    esac
 fi
 
+
+# Function to check if venv is installed
+function is_venv_installed {
+    if [ -n "$(command -v python3 -m venv)" ]; then
+        return 0
+    else
+        return 1
+    fi
+}
 
 # Function to check if Qt is installed
 function is_qt_installed {
@@ -113,18 +150,57 @@ function install_python_bindings {
     fi
 }
 
-install_python_bindings
-
 cd ../client
-python3 -m pip install -r requirements.txt GitPython
-python3 _version.py
 executableDir='/opt/NSO-RPC/'
 
 # Check if installation directory already exists
 if [ -d "$executableDir" ]; then
-    echo "[NSO-RPC: Installer]: Installation directory already exists. Removing existing directory..."
+    echo -e "${YELLOW}[NSO-RPC: Installer] Installation directory already exists. Removing existing directory..."
     sudo rm -r "$executableDir"
 fi
+
+# Check if venv is installed
+if ! is_venv_installed; then
+    sudo $PACKAGE_MANAGER install -y python3-venv
+fi
+
+
+# Check if venv is installed (if not disabled)
+if [ "$NO_VENV" != true ] && ! is_venv_installed; then
+    case "$PACKAGE_MANAGER" in
+        "apt-get" | "dnf")
+            sudo $PACKAGE_MANAGER install -y python3-venv
+            ;;
+        "pacman")
+            # Skip venv installation on Arch Linux
+            ;;
+        *)
+            echo -e "${RED}[NSO-RPC: Installer] Unsupported package manager.${RESET}"
+            exit 1
+            ;;
+    esac
+fi
+
+# Create a virtual environment (if not disabled)
+if [ "$NO_VENV" != true ]; then
+    echo -e "${YELLOW}[NSO-RPC: Installer] Creating virtual environment..."
+    python3 -m venv venv
+fi
+
+# Activate the virtual environment (if not disabled)
+if [ "$NO_VENV" != true ]; then
+    echo -e "${YELLOW}[NSO-RPC: Installer] Activating virtual environment..."
+    source venv/bin/activate
+fi
+
+# Install Python dependencies
+pip install -r requirements.txt GitPython
+
+# Install Python bindings
+install_python_bindings
+
+# Create version file
+python3 _version.py
 
 # Create the installation directory
 sudo mkdir -p "$executableDir"
@@ -143,13 +219,18 @@ mkdir -p "$iconDir"
 
 sudo cp './icon.svg' "$iconDir/nso.svg"
 
+PYTHON_EXECUTABLE="/opt/NSO-RPC/venv/bin/python"
+if [ "$NO_VENV" = true ]; then
+    PYTHON_EXECUTABLE="python3"
+fi
+
 read -r -d '' content <<EOF
 [Desktop Entry]
 Type=Application
 Name=Nintendo Switch Online Rich Presence
 GenericName=NSO-RPC
 Comment=Display your Nintendo Switch game status on Discord!
-Exec=bash -c 'cd /opt/NSO-RPC && python3 app.py'
+Exec=/bin/sh -c '. /opt/NSO-RPC/venv/bin/activate && cd /opt/NSO-RPC && exec $PYTHON_EXECUTABLE app.py'
 Icon=nso.svg
 Terminal=false
 Categories=Game;Application;Utility;

--- a/scripts/linux.sh
+++ b/scripts/linux.sh
@@ -5,9 +5,8 @@
 # Github: https://github.com/MCMi460/NSO-RPC
 #
 
-YELLOW="\e[33m"
-RESET="\e[0m"
-
+YELLOW_COLOR="\e[33m"
+RESET_COLOR="\e[0m"
 
 # Function to check if a command is available
 command_exists() {
@@ -17,10 +16,37 @@ command_exists() {
 package_managers=("apt-get" "dnf" "pacman")
 package_manager_found=false
 
+# Parse command-line arguments
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -r|--repo)
+      github_repo="$2"
+      shift 2
+      ;;
+    -b|--branch)
+      branch="$2"
+      shift 2
+      ;;
+    -n|--no-venv)
+      no_venv=false
+      shift
+      ;;
+    *)
+      echo "Unknown option: $1"
+      echo "Available options: -r/--repo, -b/--branch, -n/--no-venv"
+      exit 1
+      ;;
+  esac
+done
+
+# Default values if not provided
+github_repo="${github_repo:-MCMi460}"
+branch="${branch:-main}"
+
 # Iterate over package managers
 for manager in "${package_managers[@]}"; do
   if command_exists "$manager"; then
-    echo -e "${YELLOW}[NSO-RPC: Bootstrap] Using $manager package manager.${RESET}"
+    echo -e "${YELLOW_COLOR}[NSO-RPC: Bootstrap] Using $manager package manager.${RESET_COLOR}"
     if [ "$manager" = "pacman" ]; then
       sudo "$manager" -S --noconfirm git
     else
@@ -36,12 +62,18 @@ if ! "$package_manager_found"; then
   exit 1
 fi
 
-branch=${1:-main}
-
 if [ ! -d './NSO-RPC' ]; then
-    git clone --branch "$branch" 'https://github.com/MCMi460/NSO-RPC'
+    git clone --branch "$branch" "https://github.com/$github_repo/NSO-RPC"
 fi
 
 cd './NSO-RPC/scripts'
 chmod +x './install.sh'
-./install.sh
+
+# Pass the use_venv flag to the install.sh script
+
+
+if [ "$no_venv" = true ]; then
+  ./install.sh --no-venv
+else
+  ./install.sh
+fi

--- a/scripts/linux.sh
+++ b/scripts/linux.sh
@@ -70,8 +70,6 @@ cd './NSO-RPC/scripts'
 chmod +x './install.sh'
 
 # Pass the use_venv flag to the install.sh script
-
-
 if [ "$no_venv" = true ]; then
   ./install.sh --no-venv
 else


### PR DESCRIPTION
This PR adds a couple of fixes, however some issues still aren't addressed with this PR.

- Although this adds overrideVersion, its not 100% correctly implemented, and will cause NSO-RPC to crash on first token generation with the override, launching the app again works as intended.
_Note: This also still requires editing a file and does not have the alternative solution we discussed to prevent f-token version issues in the future._

- Now when you select a user and confirm, NSO-RPC will restart itself.

- Added support for venv that's enabled by default if using the the linux.sh & install.sh script, this is disabled via an argument and more have been added to support better customization
```
-r / --repo : What github account to use, Such as HotaruBlaze or MCMi460
-b / --branch : What github branch to clone
-n / --no-venv : Disable using venv and use python directly
```
