### PR TITLE
[Github] Add Windows Qt5 Build, Update GH Actions & Fix macos build errors.

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -4,54 +4,70 @@ on:
     types: [published]
 
 jobs:
-  build-x86_64:
-    name: 'Build NSO-RPC - x86_64'
-    runs-on: ${{ matrix.os }}
+  build-windows:
+    name: 'Build NSO-RPC - Windows'
+    runs-on: windows-latest
     strategy:
       fail-fast: false
       matrix:
-        os: ['windows-latest', 'ubuntu-latest', 'macos-latest']
+        pyqt_version:
+          - 'pyqt6'
+          - 'pyqt5'
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v3
       with:
         python-version: 3.11.4
-
-    # Windows Build
     - name: "Build"
-      if: matrix.os == 'windows-latest'
       run: |
+        python -m pip install ${{ matrix.pyqt_version }} &&
         cd scripts &&
-        python -m pip install pyqt6 &&
         ./build.bat
-
+    - name: "Rename executable"
+      if: matrix.pyqt_version == 'pyqt5'
+      run: mv client/dist/NSO-RPC.exe client/dist/NSO-RPC-qt5.exe
     - name: "Upload Build"
-      if: matrix.os == 'windows-latest'
       uses: softprops/action-gh-release@v0.1.15
       with:
-        files: client/dist/NSO-RPC.exe
+        files: |
+          client/dist/NSO-RPC*.exe
 
-    # Linux Build
+  build-linux:
+    name: 'Build NSO-RPC - Linux'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v3
+      with:
+        python-version: 3.11.4
     - name: "Upload script"
-      if: matrix.os == 'ubuntu-latest'
+      run: |
+        cd scripts &&
+        chmod +x linux.sh
+      continue-on-error: false
+    - name: "Upload Build"
       uses: softprops/action-gh-release@v0.1.15
       with:
         files: scripts/linux.sh
 
-    # MacOS Build
+  build-macos:
+    name: 'Build NSO-RPC - MacOS'
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v3
+      with:
+        python-version: 3.11.4
     - name: "Build"
-      if: matrix.os == 'macos-latest'
       run: |
         cd scripts &&
         python -m pip install pyqt6 &&
-        bash ./build.sh &&
+        ./build.sh &&
         cd ../client/dist &&
         ln -s /Applications "Applications (admin)" &&
         hdiutil create -fs HFS+ -srcfolder . -volname NSO-RPC mac-installer.dmg &&
         zip -yr mac-portable.zip NSO-RPC.app/
-
     - name: "Upload Build"
-      if: matrix.os == 'macos-latest'
       uses: softprops/action-gh-release@v0.1.15
       with:
         files: |
@@ -63,8 +79,9 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v3
-
-    # MacOS Universal Build
+    - uses: actions/setup-python@v3
+      with:
+        python-version: 3.11.4
     - name: "Install Python 3.11.4 and build NSO-RPC"
       run: |
         curl https://www.python.org/ftp/python/3.11.4/python-3.11.4-macos11.pkg -o python-3.11.4-macos11.pkg
@@ -76,7 +93,6 @@ jobs:
         ln -s /Applications "Applications (admin)" &&
         hdiutil create -fs HFS+ -srcfolder . -volname NSO-RPC mac-universal2-installer.dmg &&
         zip -yr mac-universal2-portable.zip NSO-RPC.app/
-
     - name: "Upload NSO-RPC Universal2 Build"
       uses: softprops/action-gh-release@v0.1.15
       with:
@@ -85,15 +101,16 @@ jobs:
           client/dist/mac-universal2-portable.zip
 
   get-hashes:
-    runs-on: "ubuntu-latest"
-    needs: ["build-x86_64", "build-universal2"]
+    name: 'Generate Checksums'
+    runs-on: ubuntu-latest
+    needs: [build-windows, build-linux, build-macos, build-universal2]
     steps:
-      - name: "Generate checksums.txt"
-        uses: MCJack123/ghaction-generate-release-hashes@v4
-        with:
-          hash-type: sha256
-          file-name: checksums.txt
-          get-assets: true
-      - uses: softprops/action-gh-release@v0.1.15
-        with:
-          files: checksums.txt
+    - name: "Generate checksums.txt"
+      uses: MCJack123/ghaction-generate-release-hashes@v4
+      with:
+        hash-type: sha256
+        file-name: checksums.txt
+        get-assets: true
+    - uses: softprops/action-gh-release@v0.1.15
+      with:
+        files: checksums.txt

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -14,8 +14,8 @@ jobs:
           - 'pyqt6'
           - 'pyqt5'
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: 3.11.4
     - name: "Build"
@@ -27,7 +27,7 @@ jobs:
       if: matrix.pyqt_version == 'pyqt5'
       run: mv client/dist/NSO-RPC.exe client/dist/NSO-RPC-qt5.exe
     - name: "Upload Build"
-      uses: softprops/action-gh-release@v0.1.15
+      uses: softprops/action-gh-release@v2.0.4
       with:
         files: |
           client/dist/NSO-RPC*.exe
@@ -36,8 +36,8 @@ jobs:
     name: 'Build NSO-RPC - Linux'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: 3.11.4
     - name: "Upload script"
@@ -46,7 +46,7 @@ jobs:
         chmod +x linux.sh
       continue-on-error: false
     - name: "Upload Build"
-      uses: softprops/action-gh-release@v0.1.15
+      uses: softprops/action-gh-release@v2.0.4
       with:
         files: scripts/linux.sh
 
@@ -54,8 +54,8 @@ jobs:
     name: 'Build NSO-RPC - MacOS'
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: 3.11.4
     - name: "Build"
@@ -68,7 +68,7 @@ jobs:
         hdiutil create -fs HFS+ -srcfolder . -volname NSO-RPC mac-installer.dmg &&
         zip -yr mac-portable.zip NSO-RPC.app/
     - name: "Upload Build"
-      uses: softprops/action-gh-release@v0.1.15
+      uses: softprops/action-gh-release@v2.0.4
       with:
         files: |
           client/dist/mac-installer.dmg
@@ -78,8 +78,8 @@ jobs:
     name: 'Build NSO-RPC - Universal2'
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: 3.11.4
     - name: "Install Python 3.11.4 and build NSO-RPC"
@@ -94,7 +94,7 @@ jobs:
         hdiutil create -fs HFS+ -srcfolder . -volname NSO-RPC mac-universal2-installer.dmg &&
         zip -yr mac-universal2-portable.zip NSO-RPC.app/
     - name: "Upload NSO-RPC Universal2 Build"
-      uses: softprops/action-gh-release@v0.1.15
+      uses: softprops/action-gh-release@v2.0.4
       with:
         files: |
           client/dist/mac-universal2-installer.dmg
@@ -111,6 +111,6 @@ jobs:
         hash-type: sha256
         file-name: checksums.txt
         get-assets: true
-    - uses: softprops/action-gh-release@v0.1.15
+    - uses: softprops/action-gh-release@v2.0.4
       with:
         files: checksums.txt

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,3 +1,6 @@
+#!/bin/bash
+python3 -m venv --upgrade-deps venv
+source venv/bin/activate
 cd ../client
 python3 -m pip install -r requirements.txt py2app GitPython
 python3 _version.py

--- a/scripts/macos-universal2/build.sh
+++ b/scripts/macos-universal2/build.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+python3 -m venv --upgrade-deps venv
+source venv/bin/activate
 python3 -m pip install wheel PyQt6
 bash prep-PyQt.sh
 cd ../../client


### PR DESCRIPTION
This adds a fallback Qt5 windows build, as on rare instances Qt6 does not work correctly on windows, Using Qt5 suffers from small UI differences, such as the titlebar not matching the windows theme, however is functionally the same.

![image](https://github.com/MCMi460/NSO-RPC/assets/17028801/e6b22d9d-1c0b-41fa-a6e7-0a0ca888547f)

---

This also cleans up the actions.yml such as
### Before: 
![image](https://github.com/MCMi460/NSO-RPC/assets/17028801/3f516198-9762-4a75-820f-1fb189c8eb6f)

---

### After:
![image](https://github.com/MCMi460/NSO-RPC/assets/17028801/649ac3c8-296d-4ad0-a084-32bf9692953f)
